### PR TITLE
Question regarding which bitmaps are the ones actually being .spr compressed with RLE 

### DIFF
--- a/SPR.MD
+++ b/SPR.MD
@@ -104,8 +104,8 @@ Similar to version 2.0, but now the background color (palette color with index 0
 |         Version          |    2     | 2 bytes  | binary |            Versioning information (Major.Minor)            |
 |   Indexed Frame Count    |    4     | 2 bytes  |  int   | The number of individual indexed-color images in the atlas |
 |     RGBA Frame Count     |    6     | 2 bytes  |  int   |     The number of individual RGBA images in the atlas      |
-|     Indexed Bitmaps      |    8+    | variable | struct |  The size depends on the frame count and number of pixels  |
-| RLE-Encoded RGBA Bitmaps |    8+    | variable | struct |  The size depends on the frame count and number of pixels  |
+|   RLE-Indexed Bitmaps    |    8+    | variable | struct |  The size depends on the frame count and number of pixels  |
+|    Encoded RGBA Bitmaps  |    8+    | variable | struct |  The size depends on the frame count and number of pixels  |
 |         Palette          | EOF-1024 | variable | struct |     Listed in order ABGR, defines the CLUT (see above)     |
 
 ## Tools


### PR DESCRIPTION
Based on the comments about the compression used for similar pixels:

> In the later versions, indexed-color pixels that represent the invisible background are compressed using Run-Length Encoding (see above). **This doesn't apply to the RGBA frames, however, which are not compressed**.

Would it be correct to say that the RGBA Frames are not the ones which are RLE encoded, and the table is incorrect?